### PR TITLE
TunTap was migrated to cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Dependencies
 
 [TunTap](http://tuntaposx.sourceforge.net/)
 ```
-brew install tuntap
+brew tap caskroom/cask
+brew cask install tuntap
 ```
 
 How to install it


### PR DESCRIPTION
```
Error: No available formula with the name "tuntap" 
It was migrated from homebrew/core to caskroom/cask.
You can access it again by running:
  brew tap caskroom/cask
```