### PR TITLE
fix reachability of private networks

### DIFF
--- a/sbin/docker_tap_up.sh
+++ b/sbin/docker_tap_up.sh
@@ -8,7 +8,7 @@ localTapInterface=tap1
 hostTapInterface=eth1
 
 # Local and host gateway addresses
-localGateway='10.0.75.1'
+localGateway='10.0.75.1/24'
 hostGateway='10.0.75.2'
 
 # Startup local and host tuntap interfaces


### PR DESCRIPTION
if you are in a company like me having private networks starting with an IP like 10.x.x.x you would not be able to reach that network because all these requests are heading into the linux virtualization. Having a networkmask of /24 solves that issue without breaking anything. 😊 