### PR TITLE
Add secondary check for Docker.app in ~/Applications

### DIFF
--- a/sbin/docker_tap_install.sh
+++ b/sbin/docker_tap_install.sh
@@ -32,6 +32,9 @@ for possibleLocation in $(echo '
 	if [ -f "$possibleLocation" ]; then
 		hyperkitPath=$possibleLocation
 		break;
+    elif [ -f "$HOME/$possibleLocation" ]; then
+		hyperkitPath=$HOME/$possibleLocation
+		break;
 	fi
 done
 

--- a/sbin/docker_tap_install.sh
+++ b/sbin/docker_tap_install.sh
@@ -27,13 +27,14 @@ fi
 hyperkitPath=false
 for possibleLocation in $(echo '
 	/Applications/Docker.app/Contents/MacOS/com.docker.hyperkit
+	/Applications/Docker.app/Contents/Resources/bin/com.docker.hyperkit
 	/Applications/Docker.app/Contents/Resources/bin/hyperkit
 '); do
 	if [ -f "$possibleLocation" ]; then
 		hyperkitPath=$possibleLocation
 		break;
-    elif [ -f "$HOME/$possibleLocation" ]; then
-		hyperkitPath=$HOME/$possibleLocation
+    elif [ -f "$HOME$possibleLocation" ]; then
+		hyperkitPath=$HOME$possibleLocation
 		break;
 	fi
 done


### PR DESCRIPTION
Not sure how common it is, but my Docker.app is installed in ~/Applications rather than in /Applications.
I added a secondary check for hyperkit in that directory.