### PR TITLE
Access to corporate 10.x.x.x network from Docker VM/Containers

### DIFF
--- a/sbin/docker_tap_up.sh
+++ b/sbin/docker_tap_up.sh
@@ -8,9 +8,10 @@ localTapInterface=tap1
 hostTapInterface=eth1
 
 # Local and host gateway addresses
-localGateway='10.0.75.1/24'
+localGateway='10.0.75.1/30'
 hostGateway='10.0.75.2'
+hostNetmask='255.255.255.252'
 
 # Startup local and host tuntap interfaces
 sudo ifconfig $localTapInterface $localGateway up
-docker run --rm --privileged --net=host --pid=host alpine ifconfig $hostTapInterface $hostGateway up
+docker run --rm --privileged --net=host --pid=host alpine ifconfig $hostTapInterface $hostGateway netmask $hostNetmask up


### PR DESCRIPTION
Limiting point-to-point network (Host <-> Docker VM) to /30.
Current implementation sets /8 netmask on Docker VM what leads to totally unavailable internal networks of company if 10.x.x.x subnets are used